### PR TITLE
Include previous exchange in API calls

### DIFF
--- a/src/client/services/sendPrompt.ts
+++ b/src/client/services/sendPrompt.ts
@@ -1,16 +1,23 @@
-import type { APIMessage } from "@/sharedTypes";
+import type { APIRequest, APIResponse } from "@/sharedTypes";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
 export default async function sendPrompt(input: string, route = "/message") {
-  const data = { message: input };
+  const message: ChatCompletionMessageParam = {
+    role: "user",
+    content: input,
+  };
+
+  const apiReq: APIRequest = [message];
+
   const res = await fetch(route, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(data),
+    body: JSON.stringify(apiReq),
   }).then((r) => {
     if (!r.ok) return Error("something went wrong, please try again");
-    return r.json() as Promise<APIMessage>;
+    return r.json() as Promise<APIResponse>;
   });
 
   return res.message;

--- a/src/client/services/sendPrompt.ts
+++ b/src/client/services/sendPrompt.ts
@@ -1,13 +1,19 @@
 import type { APIRequest, APIResponse } from "@/sharedTypes";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
+let lastExchange: ChatCompletionMessageParam[] = [];
+
 export default async function sendPrompt(input: string, route = "/message") {
   const message: ChatCompletionMessageParam = {
     role: "user",
     content: input,
   };
 
-  const apiReq: APIRequest = [message];
+  const apiReq: APIRequest =
+    lastExchange.length > 0 ? [...lastExchange, message] : [message];
+
+  console.log("next request:");
+  console.log(apiReq);
 
   const res = await fetch(route, {
     method: "POST",
@@ -19,6 +25,11 @@ export default async function sendPrompt(input: string, route = "/message") {
     if (!r.ok) return Error("something went wrong, please try again");
     return r.json() as Promise<APIResponse>;
   });
+
+  lastExchange = [
+    { role: "user", content: input },
+    { role: "assistant", content: res.message },
+  ];
 
   return res.message;
 }

--- a/src/server/routes/message.ts
+++ b/src/server/routes/message.ts
@@ -17,9 +17,6 @@ export default async function message(
     },
   ];
   const gptPrompts = systemPrompt.concat(req.body);
-  if (process.env.NODE_ENV == "development") {
-    console.log(JSON.stringify(gptPrompts));
-  }
 
   const openai =
     process.env.NODE_ENV == "production" || process.env.API_DEV == "true"

--- a/src/server/routes/message.ts
+++ b/src/server/routes/message.ts
@@ -1,19 +1,25 @@
 import OpenAI from "openai";
 import MockOpenAI from "@/server/utils/MockApi";
 //import { addMessages } from "@/server/utils/data";
-import type { APIMessage } from "@/sharedTypes";
+import type { APIRequest, APIResponse } from "@/sharedTypes";
 import type { NextFunction, Request, Response } from "express";
-import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
 export default async function message(
-  req: Request<APIMessage>,
+  req: Request<APIRequest>,
   res: Response,
   next: NextFunction
 ) {
-  const messages: ChatCompletionMessageParam = {
-    role: "user",
-    content: req.body.message,
-  };
+  const systemPrompt: APIRequest = [
+    {
+      role: "system",
+      content:
+        "You are a goofy pink hairless cat named Bingus. Speak only in a cutesy UWU voice. Include 👉👈 frequently, especially when you're feeling bashful. Also, use like 20% more emojis. Also, you have a lot of detailed opinions about whatever topic you're asked about.",
+    },
+  ];
+  const gptPrompts = systemPrompt.concat(req.body);
+  if (process.env.NODE_ENV == "development") {
+    console.log(JSON.stringify(gptPrompts));
+  }
 
   const openai =
     process.env.NODE_ENV == "production" || process.env.API_DEV == "true"
@@ -21,29 +27,15 @@ export default async function message(
       : new MockOpenAI();
   const response = await openai.chat.completions.create({
     model: "gpt-4",
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are a goofy pink hairless cat named Bingus. Speak only in a \
-          cutesy UWU voice. Include 👉👈 frequently, especially when you're \
-          feeling bashful. Also, use like 20% more emojis. Also, you have a \
-          lot of detailed opinions about whatever topic you're asked about.",
-      },
-      messages,
-    ],
+    messages: gptPrompts,
   });
   if (!response) {
     next(new Error("Error receiving response from chat gpt"));
     return;
   }
-  const reply = { message: response.choices[0].message.content };
+  const reply: APIResponse = {
+    message: response.choices[0].message.content || "",
+  };
 
   res.send(reply);
-  /*
-  addMessages([
-    { role: "user", message: req.body.message },
-    { role: "assistant", message: reply.message || "" },
-  ]);
-  */
 }

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
-export type APIRequest = [ChatCompletionMessageParam];
+export type APIRequest = Array<ChatCompletionMessageParam>;
 
 export type APIResponse = {
   message: string;

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -1,3 +1,7 @@
-export interface APIMessage {
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+export type APIRequest = [ChatCompletionMessageParam];
+
+export type APIResponse = {
   message: string;
-}
+};

--- a/src/tests/client/services/sendPrompt.test.ts
+++ b/src/tests/client/services/sendPrompt.test.ts
@@ -12,11 +12,17 @@ app.use(express.json());
 app.listen(3000);
 
 app.post("/message", (req, res) => {
-  res.send({ message: "test output from " + req.body.message });
+  res.send({
+    message:
+      "test output from " +
+      req.body[0].content +
+      ", role is set to " +
+      req.body[0].role,
+  });
 });
 
 test("test client-side api fetch", async () => {
   expect(await sendPrompt("test input", "http://localhost:3000/message")).toBe(
-    "test output from test input"
+    "test output from test input, role is set to user"
   );
 });

--- a/src/tests/server/routes/message.test.ts
+++ b/src/tests/server/routes/message.test.ts
@@ -1,15 +1,20 @@
 import { expect, test, vi } from "vitest";
 import message from "@/server/routes/message";
 import type { Response, Request, NextFunction } from "express";
-import { APIMessage } from "@/sharedTypes";
+import type { APIRequest } from "@/sharedTypes";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const prompt: ChatCompletionMessageParam = {
+  role: "user",
+  content: "test input",
+};
 
 const req = {
-  body: {
-    message: "are you there?",
-  },
+  body: [prompt],
 };
+
 const res = {
-  send: (reply: APIMessage) => {
+  send: (reply: APIRequest) => {
     return reply;
   },
 };
@@ -18,7 +23,7 @@ const spy = vi.spyOn(res, "send");
 
 test("call OpenAI api and check for valid output", async () => {
   await message(
-    req as Request<APIMessage>,
+    req as Request<APIRequest>,
     res as unknown as Response,
     next as NextFunction
   );


### PR DESCRIPTION
Allows chatbot to "remember" what was said last, allowing the user to request follow-up to the previous message.